### PR TITLE
Handle IllegalValueException in DataValueDeserializer

### DIFF
--- a/src/Deserializers/DataValueDeserializer.php
+++ b/src/Deserializers/DataValueDeserializer.php
@@ -2,6 +2,7 @@
 
 namespace DataValues\Deserializers;
 
+use DataValues\IllegalValueException;
 use Deserializers\DispatchableDeserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Deserializers\Exceptions\MissingAttributeException;
@@ -106,6 +107,9 @@ class DataValueDeserializer implements DispatchableDeserializer {
 			return $class::newFromArray( $this->getValue() );
 		}
 		catch ( InvalidArgumentException $ex ) {
+			throw new DeserializationException( $ex->getMessage(), $ex );
+		}
+		catch ( IllegalValueException $ex ) {
 			throw new DeserializationException( $ex->getMessage(), $ex );
 		}
 	}

--- a/tests/Deserializers/DataValueDeserializerTest.php
+++ b/tests/Deserializers/DataValueDeserializerTest.php
@@ -158,6 +158,18 @@ class DataValueDeserializerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testInvalidValueSerialization_throwsDeserializationException() {
+		$serialization = array(
+			'value' => array( 0, 0 ),
+			'type' => 'string',
+			'error' => 'omg an error!'
+		);
+
+		$deserializer = $this->newDeserializer();
+		$this->setExpectedException( 'Deserializers\Exceptions\DeserializationException' );
+		$deserializer->deserialize( $serialization );
+	}
+
 	/**
 	 * @dataProvider dataValueSerializationProvider
 	 */


### PR DESCRIPTION
IllegalValueException happens, for example, when trying to construct a TimeValue with a string, instead of an array.
