### PR TITLE
More specific type hints when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 * Handle IllegalValueException in DataValueDeserializer
 
-### 1.0 (2014-03-05)
+### 1.0.0 (2014-03-05)
 
 * Switched usage of the Serialization component from version ~2.1 to version ~3.0.
 * Switched from PSR-0 based autoloading to PSR-4 based autoloading
 * Made PHPUnit bootstrap file compatible with Windows
 
-### 0.1 (2013-12-05)
+### 0.1.0 (2013-12-05)
 
 Initial release with these features:
 

--- a/src/Deserializers/DataValueDeserializer.php
+++ b/src/Deserializers/DataValueDeserializer.php
@@ -82,7 +82,7 @@ class DataValueDeserializer implements DispatchableDeserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param array $serialization
 	 *
 	 * @throws DeserializationException
 	 * @return DataValue

--- a/src/Serializers/DataValueSerializer.php
+++ b/src/Serializers/DataValueSerializer.php
@@ -16,6 +16,11 @@ class DataValueSerializer implements DispatchableSerializer {
 
 	/**
 	 * @see Serializer::serialize
+	 *
+	 * @param DataValue $object
+	 *
+	 * @throws UnsupportedObjectException
+	 * @return array|int|string|bool|float
 	 */
 	public function serialize( $object ) {
 		if ( $this->isSerializerFor( $object ) ) {


### PR DESCRIPTION
Type hints in deserializers and such should be `mixed` when a method returns a boolean, but as specific as possible when a method is guaranteed to throw an exception otherwise.