### PR TITLE
Remove unused code from DataValueSerializer

### DIFF
--- a/src/Serializers/DataValueSerializer.php
+++ b/src/Serializers/DataValueSerializer.php
@@ -24,17 +24,13 @@ class DataValueSerializer implements DispatchableSerializer {
 	 */
 	public function serialize( $object ) {
 		if ( $this->isSerializerFor( $object ) ) {
-			return $this->getSerializedDataValue( $object );
+			return $object->toArray();
 		}
 
 		throw new UnsupportedObjectException(
 			$object,
 			'DataValueSerializer can only serialize DataValue objects'
 		);
-	}
-
-	protected function getSerializedDataValue( DataValue $dataValue ) {
-		return $dataValue->toArray();
 	}
 
 	/**
@@ -45,7 +41,7 @@ class DataValueSerializer implements DispatchableSerializer {
 	 * @return bool
 	 */
 	public function isSerializerFor( $object ) {
-		return is_object( $object ) && $object instanceof DataValue;
+		return $object instanceof DataValue;
 	}
 
 }


### PR DESCRIPTION
This is a breaking change because there may be a subclass overriding the protected method that is now removed. However, I assume this method was never intended to be part of the interface of this class.