### PR TITLE
Add PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
 		"data-values/data-values": "~1.0|~0.1",
 		"serialization/serialization": "~3.0"
 	},
+	"require-dev": {
+		"mediawiki/mediawiki-codesniffer": "~0.5"
+	},
 	"autoload": {
 		"psr-4": {
 			"DataValues\\Serializers\\": "src/Serializers",
@@ -37,5 +40,10 @@
 		"branch-alias": {
 			"dev-master": "1.1.x-dev"
 		}
+	},
+	"scripts": {
+		"phpcs": [
+			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml -sp"
+		]
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="DataValuesSerialization">
+	<!-- See https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml -->
+	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
+	</rule>
+
+	<rule ref="Generic.Files.LineLength">
+		<properties>
+			<property name="lineLimit" value="113" />
+		</properties>
+	</rule>
+
+	<arg name="extensions" value="php" />
+</ruleset>


### PR DESCRIPTION
This is the most minimal patch I can think of to add PHPCS support to this component. I'm reusing the predefined MediaWiki rule set with no additional rules (for now).
