### PR TITLE
Add more descriptive error message for DataValue class mapping

### DIFF
--- a/src/Deserializers/DataValueDeserializer.php
+++ b/src/Deserializers/DataValueDeserializer.php
@@ -49,7 +49,11 @@ class DataValueDeserializer implements DispatchableDeserializer {
 			if ( !is_string( $type )
 				|| ( !is_callable( $builder ) && !$this->isDataValueClass( $builder ) )
 			) {
-				throw new InvalidArgumentException( '$builders must map data types to callables or class names' );
+				$msg = '$builders must map data types to callables or class names';
+				if ( is_string( $builder ) ) {
+					$msg .= "'$builder' is not a DataValue class.";
+				}
+				throw new InvalidArgumentException( $msg );
 			}
 		}
 	}

--- a/src/Deserializers/DataValueDeserializer.php
+++ b/src/Deserializers/DataValueDeserializer.php
@@ -49,11 +49,11 @@ class DataValueDeserializer implements DispatchableDeserializer {
 			if ( !is_string( $type )
 				|| ( !is_callable( $builder ) && !$this->isDataValueClass( $builder ) )
 			) {
-				$msg = '$builders must map data types to callables or class names';
+				$message = '$builders must map data types to callables or class names';
 				if ( is_string( $builder ) ) {
-					$msg .= "'$builder' is not a DataValue class.";
+					$message .= ". '$builder' is not a DataValue class.";
 				}
-				throw new InvalidArgumentException( $msg );
+				throw new InvalidArgumentException( $message );
 			}
 		}
 	}


### PR DESCRIPTION
This change reports which element of $builders is at fault when
throwing an InvalidArgumentException.