### PR TITLE
Add builder info to exception.

### DIFF
--- a/src/Deserializers/DataValueDeserializer.php
+++ b/src/Deserializers/DataValueDeserializer.php
@@ -49,7 +49,7 @@ class DataValueDeserializer implements DispatchableDeserializer {
 			if ( !is_string( $type )
 				|| ( !is_callable( $builder ) && !$this->isDataValueClass( $builder ) )
 			) {
-				$message = '$builders must map data types to callables or class names';
+				$message = '$builders must map data types to callables or class names: ' . $builder;
 				if ( is_string( $builder ) ) {
 					$message .= ". '$builder' is not a DataValue class.";
 				}


### PR DESCRIPTION
Following along with https://github.com/addwiki/wikibase-api#load--general-setup some DateValuesClasses are not found on my system. But there is no clue which one. This patch added the info.