### PR TITLE
Check value is array before passing to DataValueDeserializer::newFromArray

### DIFF
--- a/src/Deserializers/DataValueDeserializer.php
+++ b/src/Deserializers/DataValueDeserializer.php
@@ -138,7 +138,14 @@ class DataValueDeserializer implements DispatchableDeserializer {
 		}
 
 		try {
-			return $builder::newFromArray( $this->getValue() );
+			$value = $this->getValue();
+
+			if ( !is_array( $value ) ) {
+				throw new DeserializationException( '$value must be an array but is '
+					. gettype( $value ) );
+			}
+
+			return $builder::newFromArray( $value );
 		} catch ( InvalidArgumentException $ex ) {
 			throw new DeserializationException( $ex->getMessage(), $ex );
 		}


### PR DESCRIPTION
It's possible that a value being handled in DataValueDeserializer::newFromArray is not an array, so we need to check.

Bug: T168681