### PR TITLE
Same exception handling for both DataValueDeserializer methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 ## Release notes
 
-### 1.2.1 (dev)
+### 1.2.1 (2017-06-23)
 
-* Raised required PHP version from 5.3 to 5.5.
+* Fixed `DataValueDeserializer` not always turning internal `InvalidArgumentException` into
+  `DeserializationException`, as documented.
+* Raised required PHP version from 5.3 to 5.5.9.
 
 ### 1.2.0 (2017-01-31)
 

--- a/composer.json
+++ b/composer.json
@@ -45,10 +45,11 @@
 	"scripts": {
 		"test": [
 			"@validate --no-interaction",
-			"vendor/bin/phpunit"
+			"@phpcs",
+			"phpunit"
 		],
 		"phpcs": [
-			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml -sp"
+			"phpcs src/* tests/* --standard=phpcs.xml -sp"
 		]
 	}
 }

--- a/src/Deserializers/DataValueDeserializer.php
+++ b/src/Deserializers/DataValueDeserializer.php
@@ -133,11 +133,12 @@ class DataValueDeserializer implements DispatchableDeserializer {
 	private function getDeserialization() {
 		$builder = $this->builders[$this->getType()];
 
-		if ( is_callable( $builder ) ) {
-			return $builder( $this->getValue() );
-		}
-
 		try {
+			if ( is_callable( $builder ) ) {
+				return $builder( $this->getValue() );
+			}
+
+			/** @var DataValue $builder */
 			return $builder::newFromArray( $this->getValue() );
 		} catch ( InvalidArgumentException $ex ) {
 			throw new DeserializationException( $ex->getMessage(), $ex );


### PR DESCRIPTION
InvalidArgumentException should be turned into DeserializationException, and this should be done in both cases: with the old method that expected the DataValue class to have a `newFromArray` method, and with the new method using callbacks.

[Bug: T168681](https://phabricator.wikimedia.org/T168681)