### PR TITLE
Use Wikibase's CodeSniffer instead of MediaWiki's

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
 		"serialization/serialization": "~3.0"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": ">=0.4 <0.8",
-		"phpunit/phpunit": "~4.8"
+		"phpunit/phpunit": "~4.8",
+		"wikibase/wikibase-codesniffer": "^0.1.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,45 +1,12 @@
 <?xml version="1.0"?>
 <ruleset name="DataValuesSerialization">
-	<!-- See https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml -->
-	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
-		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
-	</rule>
+	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase" />
 
-	<rule ref="Generic.ControlStructures" />
 	<rule ref="Generic.Files.LineLength">
 		<properties>
 			<property name="lineLimit" value="113" />
 		</properties>
 	</rule>
-	<rule ref="Generic.PHP.CharacterBeforePHPOpeningTag" />
-
-	<rule ref="PSR1" />
-	<rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
-		<!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
-		<exclude-pattern>tests*Test*\.php</exclude-pattern>
-	</rule>
-
-	<rule ref="PSR2.Files" />
-
-	<rule ref="Squiz.Classes.DuplicateProperty" />
-	<rule ref="Squiz.Classes.SelfMemberReference" />
-	<rule ref="Squiz.ControlStructures.ControlSignature" />
-	<rule ref="Squiz.Functions.FunctionDuplicateArgument" />
-	<rule ref="Squiz.Functions.GlobalFunction" />
-	<rule ref="Squiz.Scope" />
-	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
-		<properties>
-			<property name="spacing" value="1" />
-		</properties>
-	</rule>
-	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
-		<properties>
-			<property name="ignoreNewlines" value="true" />
-		</properties>
-	</rule>
 
 	<file>.</file>
-	<exclude-pattern type="relative">^vendor/</exclude-pattern>
-	<arg name="extensions" value="php" />
-	<arg name="encoding" value="utf8" />
 </ruleset>

--- a/src/Deserializers/DataValueDeserializer.php
+++ b/src/Deserializers/DataValueDeserializer.php
@@ -37,7 +37,7 @@ class DataValueDeserializer implements DispatchableDeserializer {
 	 *  corresponding DataValue::getArrayValue, and return a new DataValue object. DataValue classes
 	 *  given via class name must implement a static newFromArray method doing the same.
 	 */
-	public function __construct( array $builders = array() ) {
+	public function __construct( array $builders = [] ) {
 		$this->assertAreDataValueClasses( $builders );
 		$this->builders = $builders;
 	}

--- a/tests/Deserializers/DataValueDeserializerTest.php
+++ b/tests/Deserializers/DataValueDeserializerTest.php
@@ -24,17 +24,17 @@ class DataValueDeserializerTest extends PHPUnit_Framework_TestCase {
 
 	public function testGivenEmptyArray_isDeserializerForReturnsFalse() {
 		$deserializer = $this->newDeserializer();
-		$this->assertFalse( $deserializer->isDeserializerFor( array() ) );
+		$this->assertFalse( $deserializer->isDeserializerFor( [] ) );
 	}
 
 	private function newDeserializer() {
-		return new DataValueDeserializer( array(
+		return new DataValueDeserializer( [
 			'boolean' => function( $bool ) {
 				return new BooleanValue( $bool );
 			},
 			'number' => NumberValue::class,
 			'string' => StringValue::class,
-		) );
+		] );
 	}
 
 	/**
@@ -46,13 +46,13 @@ class DataValueDeserializerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function notAnArrayProvider() {
-		return array(
-			array( null ),
-			array( 0 ),
-			array( true ),
-			array( (object)array() ),
-			array( 'foo' ),
-		);
+		return [
+			[ null ],
+			[ 0 ],
+			[ true ],
+			[ new \stdClass() ],
+			[ 'foo' ],
+		];
 	}
 
 	/**
@@ -65,64 +65,55 @@ class DataValueDeserializerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function notADataValuesListProvider() {
-		return array(
-			array(
-				array(
+		return [
+			[
+				[
 					'foo',
 					null,
-					array(),
+					[],
 					true,
 					42,
-				)
-			),
-			array(
-				array(
+				]
+			],
+			[
+				[
 					'string' => 'foo',
-				)
-			),
-			array(
-				array(
+				]
+			],
+			[
+				[
 					'string' => StringValue::class,
 					'number' => 42,
-				)
-			),
-			array(
-				array(
+				]
+			],
+			[
+				[
 					'string' => StringValue::class,
 					'object' => 'stdClass',
-				)
-			)
-		);
+				]
+			]
+		];
 	}
 
 	public function testGivenSerializationNoType_deserializeThrowsException() {
 		$deserializer = $this->newDeserializer();
 
 		$this->setExpectedException( MissingTypeException::class );
-		$deserializer->deserialize( array() );
+		$deserializer->deserialize( [] );
 	}
 
 	public function testGivenSerializationWithUnknownType_deserializeThrowsException() {
 		$deserializer = $this->newDeserializer();
 
 		$this->setExpectedException( UnsupportedTypeException::class );
-		$deserializer->deserialize(
-			array(
-				'value' => null,
-				'type' => 'ohi'
-			)
-		);
+		$deserializer->deserialize( [ 'type' => 'ohi', 'value' => null ] );
 	}
 
 	public function testGivenSerializationWithNoValue_deserializeThrowsException() {
 		$deserializer = $this->newDeserializer();
 
 		$this->setExpectedException( MissingAttributeException::class );
-		$deserializer->deserialize(
-			array(
-				'type' => 'number'
-			)
-		);
+		$deserializer->deserialize( [ 'type' => 'number' ] );
 	}
 
 	/**
@@ -148,11 +139,11 @@ class DataValueDeserializerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testInvalidValueSerialization_throwsDeserializationException() {
-		$serialization = array(
-			'value' => array( 0, 0 ),
+		$serialization = [
+			'value' => [ 0, 0 ],
 			'type' => 'string',
 			'error' => 'omg an error!'
-		);
+		];
 
 		$deserializer = $this->newDeserializer();
 		$this->setExpectedException( DeserializationException::class );
@@ -172,11 +163,11 @@ class DataValueDeserializerTest extends PHPUnit_Framework_TestCase {
 		$string = new StringValue( 'foo bar baz' );
 		$number = new NumberValue( 42 );
 
-		return array(
-			array( $boolean->toArray(), 'boolean' ),
-			array( $string->toArray(), 'string' ),
-			array( $number->toArray(), 'number' ),
-		);
+		return [
+			[ $boolean->toArray(), 'boolean' ],
+			[ $string->toArray(), 'string' ],
+			[ $number->toArray(), 'number' ],
+		];
 	}
 
 	/**

--- a/tests/Serializers/DataValueSerializerTest.php
+++ b/tests/Serializers/DataValueSerializerTest.php
@@ -27,16 +27,16 @@ class DataValueSerializerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function notADataValueProvider() {
-		return array(
-			array( 0 ),
-			array( null ),
-			array( '' ),
-			array( array() ),
-			array( true ),
-			array( 4.2 ),
-			array( (object)array() ),
-			array( new \Exception() ),
-		);
+		return [
+			[ 0 ],
+			[ null ],
+			[ '' ],
+			[ [] ],
+			[ true ],
+			[ 4.2 ],
+			[ new \stdClass() ],
+			[ new \Exception() ],
+		];
 	}
 
 	/**
@@ -49,10 +49,10 @@ class DataValueSerializerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function dataValueProvider() {
-		return array(
-			array( new StringValue( 'foo' ) ),
-			array( new NumberValue( 42 ) ),
-		);
+		return [
+			[ new StringValue( 'foo' ) ],
+			[ new NumberValue( 42 ) ],
+		];
 	}
 
 	/**


### PR DESCRIPTION
Changing the array syntax in the same patch because it's not that much here in this code repository.

[Bug: T167436](https://phabricator.wikimedia.org/T167436)