### PR TITLE
Remove not needed "composer phpcs" command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,11 +45,8 @@
 	"scripts": {
 		"test": [
 			"@validate --no-interaction",
-			"@phpcs",
+			"phpcs -p -s",
 			"phpunit"
-		],
-		"phpcs": [
-			"phpcs src/* tests/* --standard=phpcs.xml -sp"
 		]
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -38,6 +38,8 @@
 		</properties>
 	</rule>
 
+	<file>.</file>
+	<exclude-pattern type="relative">^vendor/</exclude-pattern>
 	<arg name="extensions" value="php" />
 	<arg name="encoding" value="utf8" />
 </ruleset>


### PR DESCRIPTION
This is the exact same as https://github.com/DataValues/Time/pull/135. This command is not used and not needed any more as a shortcut, because the commans got simplified so much.