### PR TITLE
Release 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 ## Release notes
 
+### 1.2.2 (2017-10-25)
+
+* Made component installable together Serialization 4.x
+
 ### 1.2.1 (2017-06-26)
 
 * Fixed `DataValueDeserializer` not always turning internal `InvalidArgumentException` into

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
 	"require": {
 		"php": ">=5.5.9",
 		"data-values/data-values": "~1.0|~0.1",
-		"serialization/serialization": "~3.0"
+		"serialization/serialization": "~4.0|~3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8",
-		"wikibase/wikibase-codesniffer": "^0.1.0"
+		"wikibase/wikibase-codesniffer": "^0.2.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="DataValuesSerialization">
-	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase" />
-
-	<rule ref="Generic.Files.LineLength">
-		<properties>
-			<property name="lineLimit" value="113" />
-		</properties>
-	</rule>
+<ruleset>
+	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase" />
 
 	<file>.</file>
 </ruleset>

--- a/tests/Deserializers/DataValueDeserializerTest.php
+++ b/tests/Deserializers/DataValueDeserializerTest.php
@@ -173,7 +173,10 @@ class DataValueDeserializerTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider dataValueSerializationProvider
 	 */
-	public function testGivenDataValueSerialization_deserializeReturnsDataValue( $dvSerialization, $expectedType ) {
+	public function testGivenDataValueSerialization_deserializeReturnsDataValue(
+		$dvSerialization,
+		$expectedType
+	) {
 		$deserializer = $this->newDeserializer();
 
 		$dataValue = $deserializer->deserialize( $dvSerialization );


### PR DESCRIPTION
After https://github.com/wmde/Serialization/pull/21 this here is the next step. It's really simple: Even if the Serialization 4.0.0 release is a breaking one, no code is affected because I made sure to only remove classes and methods that are unused anyway.