### PR TITLE
1.2.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 ## Release notes
 
+### 1.2.3 (2018-12-01)
+
+* Made component installable together with DataValues 2.x
+
 ### 1.2.2 (2017-10-25)
 
 * Made component installable together with Serialization 4.x


### PR DESCRIPTION
Release https://github.com/DataValues/Serialization/commit/37f8fe94ecb25549268ee8044dc4e7078e5a6fcc which is needed for Wikibase to be able to use DataValues 2.x at last (released almost a year and a half ago now :D)