### PR TITLE
Add helpful message MissingTypeException

### DIFF
--- a/src/Deserializers/DataValueDeserializer.php
+++ b/src/Deserializers/DataValueDeserializer.php
@@ -93,7 +93,7 @@ class DataValueDeserializer implements DispatchableDeserializer {
 
 	private function assertCanDeserialize( $serialization ) {
 		if ( !is_array( $serialization ) || !array_key_exists( self::TYPE_KEY, $serialization ) ) {
-			throw new MissingTypeException( json_encode( $serialization ) . ' is not an array or missing the key ' . self::TYPE_KEY );
+			throw new MissingTypeException( 'Not an array or missing the key "' . self::TYPE_KEY . '"' );
 		}
 
 		if ( !array_key_exists( self::VALUE_KEY, $serialization ) ) {

--- a/src/Deserializers/DataValueDeserializer.php
+++ b/src/Deserializers/DataValueDeserializer.php
@@ -93,7 +93,7 @@ class DataValueDeserializer implements DispatchableDeserializer {
 
 	private function assertCanDeserialize( $serialization ) {
 		if ( !is_array( $serialization ) || !array_key_exists( self::TYPE_KEY, $serialization ) ) {
-			throw new MissingTypeException();
+			throw new MissingTypeException( json_encode( $serialization ) . ' is not an array or missing the key ' . self::TYPE_KEY );
 		}
 
 		if ( !array_key_exists( self::VALUE_KEY, $serialization ) ) {


### PR DESCRIPTION
This message is used in the api response and should not just be an empty string.

Also, we can not rely on a default message (being fixed in wmde/Serialization#34)